### PR TITLE
Necessary table fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Specifications for the SUAVE protocol are currently organized by testnet during 
 
 | Testnet | Phase | ChainID | Specs |
 | - | - | - | - |
-| **Rigil**  | [Big Bang](/assets/future_roadmap_draft.png) | `16813125` | • [SUAVE chain](./specs/rigil/suave-chain.md) <br/> • [MEVM](./specs/rigil/mevm.md) <br/> • [Confidential Data Store](./specs/rigil/confidential-data-store.md) <br/> • [Precompiles](./specs/rigil/precompiles.md) <br/> • [Bridge](./specs/rigil/bridge.md)  |
+| [**Rigil**](./specs/rigil/)  | [Big Bang](/assets/future_roadmap_draft.png) | `16813125` | • [SUAVE chain](./specs/rigil/suave-chain.md) <br/> • [MEVM](./specs/rigil/mevm.md) <br/> • [Confidential Data Store](./specs/rigil/confidential-data-store.md) <br/> • [Precompiles](./specs/rigil/precompiles.md) <br/> • [Bridge](./specs/rigil/bridge.md)  |
 | **Sirrah** | [Proto-Collision](/assets/future_roadmap_draft.png) | | |
 
 ---


### PR DESCRIPTION
Even if this top-level README is not included in the rendered docs website, it's mere presence there offends Docusaurus in its current form...

This PR fixes just this error.

```
SyntaxError: /home/andy/flashbots/suave-docs/docs/technical/README.md: Expected corresponding JSX closing tag for <td>. (33:539)
  31 | <td parentName="tr" {...{"align":null}}><a target="_blank" href={require('!/home/andy/flashbots/suave-docs/node_modules/file-loader/dist/cjs.js?name=assets/files/[name]-[contenthash].[ext]!./../../static/assets/future_roadmap_draft.png').default}>Big Bang</a></td>
  32 | <td parentName="tr" {...{"align":null}}><inlineCode parentName="td">{`16813125`}</inlineCode></td>
> 33 | <td parentName="tr" {...{"align":null}}><ul><li><a parentName="td" {...{"href":"/technical/specs/rigil/suave-chain"}}>{`Suave Chain`}</a></li><li><a parentName="td" {...{"href":"/technical/specs/rigil/mevm"}}>{`MEVM`}</a></li><li><a parentName="td" {...{"href":"/technical/specs/rigil/confidential-data-store"}}>{`Confidential Data Store`}</a></li><li><a parentName="td" {...{"href":"/technical/specs/rigil/precompiles"}}>{`Precompiles`}</a></li><li><a parentName="td" {...{"href":"/technical/specs/rigil/bridge"}}>{`Bridge`}</a></li></ul></ul></td>
     |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            ^
  34 | </tr>
  35 | <tr parentName="tbody">
  36 | <td parentName="tr" {...{"align":null}}><a parentName="td" {...{"href":"/specs/sirrah/"}}>{`Sirrah`}</a></td>
client (webpack 5.75.0) compiled with 1 error
```