### PR TITLE
General hide div

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # ☀️ SUAVE Protocol Specifications
 
-<div class="toc">
+<div class="hideInDocs">
 
 [![Rigil specs ./specs/rigil/](https://img.shields.io/badge/jump%20into-Rigil%20Specs-purple.svg)](./specs/rigil/)
 [![Docs at https://suave.flashbots.net/](https://img.shields.io/badge/read-SUAVE%20docs-blue.svg)](https://suave.flashbots.net/)
 [![Join the chat at https://collective.flashbots.net/](https://img.shields.io/badge/chat-on%20Flashbots%20forum-blue.svg)](https://collective.flashbots.net/)
 
-</div>
-
 This repository hosts the current SUAVE specifications.
+
+</div>
 
 Discussions about design rationale and proposed changes can be brought up and discussed on the [Flashbots forum](https://collective.flashbots.net/). Solidified, agreed-upon changes to the spec can be made through pull requests.
 
@@ -33,4 +33,10 @@ Specifications for the SUAVE protocol are currently organized by testnet during 
 
 You are welcome to open PRs and issues. We invite you to discuss your ideas in the [Flashbots Forum](https://collective.flashbots.net/) for greater visibility and to avoid doing work that is unlikely to be widely accepted and merged into the core specs.
 
-For creating tables of contents, we use the [xavierguarch.auto-markdown-toc VS code extension](https://marketplace.visualstudio.com/items?itemName=xavierguarch.auto-markdown-toc) and recommend the following user setting: `"markdown-toc.depthFrom": 2`. However, we don't need these ToCs rendered in the documentation frontend. Therefore, please add the `<div class="toc"></div>` to any content that should not appear in the FE.
+<div class="hideInDocs">
+
+For creating tables of contents, we use the [xavierguarch.auto-markdown-toc VS code extension](https://marketplace.visualstudio.com/items?itemName=xavierguarch.auto-markdown-toc) and recommend the following user setting: `"markdown-toc.depthFrom": 2`. 
+
+However, we don't need the ToCs and some other content (like this paragraph) rendered in the documentation frontend. Therefore, please add the `<div class="hideInDocs"></div>` to any content that should not appear in the FE.
+
+</div>

--- a/specs/rigil/confidential-data-store.md
+++ b/specs/rigil/confidential-data-store.md
@@ -1,6 +1,6 @@
 # Confidential Data Store
 
-<div class="toc">
+<div class="hideInDocs">
 
 **Table of Contents**
 

--- a/specs/rigil/mevm.md
+++ b/specs/rigil/mevm.md
@@ -1,6 +1,6 @@
 # MEVM
 
-<div class="toc">
+<div class="hideInDocs">
 
 **Table of Contents**
 

--- a/specs/rigil/precompiles.md
+++ b/specs/rigil/precompiles.md
@@ -1,6 +1,6 @@
 # Precompiles
 
-<div class="toc">
+<div class="hideInDocs">
 
 **Table of Contents**
 

--- a/specs/rigil/suave-chain.md
+++ b/specs/rigil/suave-chain.md
@@ -1,6 +1,6 @@
 # Suave Chain
 
-<div class="toc">
+<div class="hideInDocs">
 
 **Table of Contents**
 


### PR DESCRIPTION
Gives the div we use to hide content from the specs when it appears in the docs FE a more general name so as not to confuse engineers :innocent: 