### PR TITLE
fix toc generation, use new vs code ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- no toc -->
 # ☀️ SUAVE Protocol Specifications
 
 <div class="hideInDocs">
@@ -17,13 +18,6 @@ Discussions about design rationale and proposed changes can be brought up and di
 ⚠️ The SUAVE protocol is still in a state where [the code](https://github.com/flashbots/suave-geth) is the most up-to-date protocol spec. The goal of these notes is to gradually evolve into an implementation agnostic specification. ⚠️
 
 </div>
-
-<!-- TOC depthfrom:10 -->
-
-
-
-<!-- /TOC -->
-
 
 ---
 
@@ -45,10 +39,10 @@ Specifications for the SUAVE protocol are currently organized by testnet during 
 
 ## In-development Specifications
 
-| Testnet | Phase | ChainID | Specs |
-| - | - | - | - |
-| [**Rigil**](./specs/rigil/)  | [Big Bang](/assets/future_roadmap_draft.png) | `16813125` | • [SUAVE chain](./specs/rigil/suave-chain.md) <br/> • [MEVM](./specs/rigil/mevm.md) <br/> • [Confidential Data Store](./specs/rigil/confidential-data-store.md) <br/> • [Precompiles](./specs/rigil/precompiles.md) <br/> • [Bridge](./specs/rigil/bridge.md)  |
-| [**Sirrah**](./specs/sirrah/) | [Proto-Collision](/assets/future_roadmap_draft.png) | | |
+| Testnet                       | Phase                                               | ChainID    | Specs                                                                                                                                                                                                                                                         |
+| ----------------------------- | --------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [**Rigil**](./specs/rigil/)   | [Big Bang](/assets/future_roadmap_draft.png)        | `16813125` | • [SUAVE chain](./specs/rigil/suave-chain.md) <br/> • [MEVM](./specs/rigil/mevm.md) <br/> • [Confidential Data Store](./specs/rigil/confidential-data-store.md) <br/> • [Precompiles](./specs/rigil/precompiles.md) <br/> • [Bridge](./specs/rigil/bridge.md) |
+| [**Sirrah**](./specs/sirrah/) | [Proto-Collision](/assets/future_roadmap_draft.png) |            |                                                                                                                                                                                                                                                               |
 
 ---
 
@@ -58,7 +52,7 @@ You are welcome to open PRs and issues. We invite you to discuss your ideas in t
 
 <div class="hideInDocs">
 
-For creating tables of contents, we use the [huntertran.auto-markdown-toc VS code extension](https://marketplace.visualstudio.com/items?itemName=huntertran.auto-markdown-toc).
+For creating tables of contents, we use the ["Markdown All in One" VS code extension](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one). This extension comes with a lot of keyboard shortcuts, which may override the ones you are already using. You can disable keyboard shortcuts for this extension by going to "Settings -> Keyboard Shortcuts" (cmd+K cmd+S) and searching for `markdown.ext` (see [#22](https://github.com/flashbots/suave-specs/pull/22) for more details).
 
 However, we don't need the ToCs and some other content (like this paragraph) rendered in the documentation frontend. Therefore, please add the `<div class="hideInDocs"></div>` to any content that should not appear in the FE.
 

--- a/specs/rigil/README.md
+++ b/specs/rigil/README.md
@@ -1,3 +1,4 @@
+<!-- no toc -->
 # SUAVE Rigil Testnet
 
 [![Docs at https://suave.flashbots.net/](https://img.shields.io/badge/read-SUAVE%20docs-blue.svg)](https://suave.flashbots.net/)
@@ -12,14 +13,6 @@ This repository hosts the current SUAVE Rigil testnet specifications and design 
 </div>
 
 <div class="hideInDocs">
-
-
-<!-- TOC depthfrom:10 -->
-
-
-
-<!-- /TOC -->
-
 
 ---
 

--- a/specs/rigil/bridge.md
+++ b/specs/rigil/bridge.md
@@ -1,4 +1,5 @@
-# Bridge
+<!-- no toc -->
+# Bridge <!-- omit from toc -->
 
 SUAVE uses a bridge with the Goerli Ethereum network to transfer assets for gas and MEV applications.
 

--- a/specs/rigil/computor.md
+++ b/specs/rigil/computor.md
@@ -1,29 +1,36 @@
-# Computor
+# Computor <!-- omit from toc -->
+
+<div class="hideInDocs">
+
+**Table of Contents**
 
 <!-- TOC -->
+
 - [Overview](#overview)
 - [Prerequisites](#prerequisites)
 - [Computor Responsibilities](#computor-responsibilities)
 - [Becoming a Computor](#becoming-a-computor)
-    - [Computor Identification](#computor-identification)
+  - [Computor Identification](#computor-identification)
 - [Computor Architecture](#computor-architecture)
-    - [RPC](#rpc)
-    - [SUAVE PoA Chain](#suave-poa-chain)
-    - [MEVM](#mevm)
-    - [Confidential Data Store](#confidential-data-store)
-    - [Domain Specific Services](#domain-specific-services)
-    - [Precompiles](#precompiles)
+  - [RPC](#rpc)
+  - [SUAVE PoA Chain](#suave-poa-chain)
+  - [MEVM](#mevm)
+  - [Confidential Data Store](#confidential-data-store)
+  - [Domain Specific Services](#domain-specific-services)
+  - [Precompiles](#precompiles)
 - [Containers](#containers)
-    - [Confidential Compute Record](#confidential-compute-record)
-    - [ConfidentialComputeRequest](#confidentialcomputerequest)
-    - [Suave Transaction](#suave-transaction)
-    - [Bid](#bid)
+  - [Confidential Compute Record](#confidential-compute-record)
+  - [ConfidentialComputeRequest](#confidentialcomputerequest)
+  - [Suave Transaction](#suave-transaction)
+  - [Bid](#bid)
 - [Confidential Computation](#confidential-computation)
-    - [Confidential Compute Process](#confidential-compute-process)
+  - [Confidential Compute Process](#confidential-compute-process)
 - [Honest Computor](#honest-computor)
 - [Self Organization](#self-organization)
 
 <!-- /TOC -->
+
+</div>
 
 ## Overview
 This document provides the technical specification for the SUAVE computor: one of the main protocol actors in the SUAVE protocol. The computor contains all necessary components to aceept, process, and route confidential compute requests and results. With these basic primitives computors can self-organize their topology and functionality to conform to specific portions of the MEV supply network.
@@ -55,7 +62,7 @@ A computor has several primary responsibilities within the SUAVE network:
 
 ## Becoming a Computor
 
-Computors are currently permissioned in the SUAVE network, to become one you need your computor's ECDSA pubkey to be contained within the clique PoA genesis settings. 
+Computors are currently permissioned in the SUAVE network, to become one you need your computor's ECDSA pubkey to be contained within the clique PoA genesis settings.
 
 While permissioned now, Computors will one day become permisisonless.
 
@@ -160,7 +167,7 @@ type SuaveTransaction struct {
 
 ### Bid
 
-Bids are the underlying data structure used to track and access data from confidential data storage. 
+Bids are the underlying data structure used to track and access data from confidential data storage.
 
 ```go
 type Bid struct {
@@ -197,8 +204,8 @@ On the Rigil testnet Computors do not live inside of Trusted Execution Environme
 
 ## Self Organization
 
-Traditionally, synchrony has been viewed as a cooperative event. However, evidence from the mempool suggests that a collective synchronous display can also be an incidental outcome of signal "jamming" activities, often known as priority gas auctions, between actors competing for blockspace. 
+Traditionally, synchrony has been viewed as a cooperative event. However, evidence from the mempool suggests that a collective synchronous display can also be an incidental outcome of signal "jamming" activities, often known as priority gas auctions, between actors competing for blockspace.
 
-In this light, the existing MEV supply chain we have today can be seen as a [Turing Pattern](https://en.wikipedia.org/wiki/Turing_pattern) resulting from instability in the supply chain. 
+In this light, the existing MEV supply chain we have today can be seen as a [Turing Pattern](https://en.wikipedia.org/wiki/Turing_pattern) resulting from instability in the supply chain.
 
 SUAVE computors embrace this phenomenon with the capability to reconfigure their network communication to fit into the specific subsection of the MEV supply network they serve. Currently, SUAVE computors route the outcomes of confidential compute, bundles, and blocks directly to the desired recipient party as the network maintains a small and compact topology. The eventual goal is to foster a more dynamic self-organization to cater to a broader network topology and enable autonomous self organization.

--- a/specs/rigil/confidential-data-store.md
+++ b/specs/rigil/confidential-data-store.md
@@ -1,20 +1,20 @@
-# Confidential Data Store
+# Confidential Data Store <!-- omit from toc -->
 
 <div class="hideInDocs">
 
 **Table of Contents**
 
-<!-- TOC depthfrom:2 -->
+<!-- TOC -->
 
 - [Introduction](#introduction)
 - [Architecture Diagram](#architecture-diagram)
 - [Core Components](#core-components)
-    - [ConfidentialStore](#confidentialstore)
-    - [SUAVE Mempool](#suave-mempool)
-    - [Interface Definitions](#interface-definitions)
+  - [ConfidentialStore](#confidentialstore)
+  - [SUAVE Mempool](#suave-mempool)
+  - [Interface Definitions](#interface-definitions)
 - [Data Management](#data-management)
-    - [Initialization & Access Control](#initialization--access-control)
-    - [Store & Retrieve Processes](#store--retrieve-processes)
+  - [Initialization \& Access Control](#initialization--access-control)
+  - [Store \& Retrieve Processes](#store--retrieve-processes)
 - [Security and Confidentiality](#security-and-confidentiality)
 
 <!-- /TOC -->

--- a/specs/rigil/mevm.md
+++ b/specs/rigil/mevm.md
@@ -1,18 +1,18 @@
-# MEVM
+# MEVM <!-- omit from toc -->
 
 <div class="hideInDocs">
 
 **Table of Contents**
 
-<!-- TOC depthfrom:2 -->
+<!-- TOC -->
 
 - [Overview](#overview)
 - [Core Architecture](#core-architecture)
-    - [SuaveExecutionBackend](#suaveexecutionbackend)
-    - [MEVM Interpreter](#mevm-interpreter)
+  - [SuaveExecutionBackend](#suaveexecutionbackend)
+  - [MEVM Interpreter](#mevm-interpreter)
 - [Additional Capabilities](#additional-capabilities)
-    - [Confidential execution of smart contracts](#confidential-execution-of-smart-contracts)
-    - [Confidential APIs](#confidential-apis)
+  - [Confidential execution of smart contracts](#confidential-execution-of-smart-contracts)
+  - [Confidential APIs](#confidential-apis)
 - [MEVM Example Flow + Diagram](#mevm-example-flow--diagram)
 
 <!-- /TOC -->

--- a/specs/rigil/precompiles.md
+++ b/specs/rigil/precompiles.md
@@ -1,24 +1,24 @@
-# Precompiles
+# Precompiles <!-- omit from toc -->
 
 <div class="hideInDocs">
 
 **Table of Contents**
 
-<!-- TOC depthfrom:2 -->
+<!-- TOC -->
 
 - [Overview](#overview)
 - [Precompiles Governance](#precompiles-governance)
 - [Precompiles](#precompiles)
-    - [`IsConfidential`](#isconfidential)
-    - [`ConfidentialInputs`](#confidentialinputs)
-    - [`ConfidentialStore`](#confidentialstore)
-    - [`ConfidentialRetrieve`](#confidentialretrieve)
-    - [`NewBid`](#newbid)
-    - [`FetchBids`](#fetchbids)
-    - [`SimulateBundle`](#simulatebundle)
-    - [`ExtractHint`](#extracthint)
-    - [`BuildEthBlock`](#buildethblock)
-    - [`SubmitEthBlockBidToRelay`](#submitethblockbidtorelay)
+  - [`IsConfidential`](#isconfidential)
+  - [`ConfidentialInputs`](#confidentialinputs)
+  - [`ConfidentialStore`](#confidentialstore)
+  - [`ConfidentialRetrieve`](#confidentialretrieve)
+  - [`NewBid`](#newbid)
+  - [`FetchBids`](#fetchbids)
+  - [`SimulateBundle`](#simulatebundle)
+  - [`ExtractHint`](#extracthint)
+  - [`BuildEthBlock`](#buildethblock)
+  - [`SubmitEthBlockBidToRelay`](#submitethblockbidtorelay)
 
 <!-- /TOC -->
 

--- a/specs/rigil/suave-chain.md
+++ b/specs/rigil/suave-chain.md
@@ -1,19 +1,19 @@
-# Suave Chain
+# Suave Chain <!-- omit from toc -->
 
 <div class="hideInDocs">
 
-<!-- TOC depthfrom:2 -->
+<!-- TOC -->
 
 - [Introduction](#introduction)
 - [Configuration](#configuration)
-    - [Network Parameters](#network-parameters)
-    - [Genesis Settings](#genesis-settings)
+  - [Network Parameters](#network-parameters)
+  - [Genesis Settings](#genesis-settings)
 - [Consensus Mechanism](#consensus-mechanism)
-    - [MEVM Execution](#mevm-execution)
-    - [Geth Version](#geth-version)
+  - [MEVM Execution](#mevm-execution)
+  - [Geth Version](#geth-version)
 - [Suave Transaction](#suave-transaction)
 - [Suave JSON-RPC](#suave-json-rpc)
-    - [suavex namespace](#suavex-namespace)
+  - [`suavex` namespace](#suavex-namespace)
 - [Node Requirements and Setup](#node-requirements-and-setup)
 - [Gas and Transaction Fees](#gas-and-transaction-fees)
 - [Security Considerations](#security-considerations)
@@ -44,13 +44,13 @@ In the initial phases of development, the SUAVE chain runs a proof-of-authority 
 
 ### Genesis Settings
 
-| Name | Value | Unit |
-| - | - | - |
-| `PERIOD` | 4 | `block`
-| `EPOCH` | 30000 | `block`
-| `BLOCK_TIME` | 3 | `second`
-| `GAS_LIMIT`| 30000000 | `gwei`
-| `NUM_VALIDATORS` | 3 | Nodes
+| Name             | Value    | Unit     |
+| ---------------- | -------- | -------- |
+| `PERIOD`         | 4        | `block`  |
+| `EPOCH`          | 30000    | `block`  |
+| `BLOCK_TIME`     | 3        | `second` |
+| `GAS_LIMIT`      | 30000000 | `gwei`   |
+| `NUM_VALIDATORS` | 3        | Nodes    |
 
 ## Consensus Mechanism
 


### PR DESCRIPTION
Unified table of contents generations

Switched to https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one because all the other ToC extensions were buggy and randomly messed up the content.

This extension comes with a lot of keyboard shortcuts, which may override the ones you are already using. You can disable keyboard shortcuts for this extension by
- Go to "Settings -> Keyboard Shortcuts" (cmd+K cmd+S)
- Search for `markdown.ext`
- Right-click -> "remove keybinding":

<img width="856" alt="Screenshot 2023-10-07 at 12 31 14" src="https://github.com/flashbots/suave-specs/assets/116939/4170bbdc-f5be-4f21-976e-6ab9056db131">

