### PR TITLE
moved no-toc comments above the header to fix docs rendering

### DIFF
--- a/specs/rigil/README.md
+++ b/specs/rigil/README.md
@@ -1,4 +1,5 @@
-# SUAVE Rigil Testnet <!-- omit from toc -->
+<!-- omit from toc -->
+# SUAVE Rigil Testnet
 
 [![Docs at https://suave.flashbots.net/](https://img.shields.io/badge/read-SUAVE%20docs-blue.svg)](https://suave.flashbots.net/)
 [![Join the discourse at https://collective.flashbots.net/](https://img.shields.io/badge/chat-on%20Flashbots%20forum-blue.svg)](https://collective.flashbots.net/)

--- a/specs/rigil/bridge.md
+++ b/specs/rigil/bridge.md
@@ -1,5 +1,6 @@
 <!-- no toc -->
-# Bridge <!-- omit from toc -->
+<!-- omit from toc -->
+# Bridge
 
 SUAVE uses a bridge with the Goerli Ethereum network to transfer assets for gas and MEV applications.
 

--- a/specs/rigil/computor.md
+++ b/specs/rigil/computor.md
@@ -1,4 +1,5 @@
-# Computor <!-- omit from toc -->
+<!-- omit from toc -->
+# Computor
 
 <div class="hideInDocs">
 

--- a/specs/rigil/confidential-data-store.md
+++ b/specs/rigil/confidential-data-store.md
@@ -1,4 +1,5 @@
-# Confidential Data Store <!-- omit from toc -->
+<!-- omit from toc -->
+# Confidential Data Store
 
 <div class="hideInDocs">
 
@@ -6,7 +7,6 @@
 
 <!-- TOC -->
 
-- [Introduction](#introduction)
 - [Architecture Diagram](#architecture-diagram)
 - [Core Components](#core-components)
   - [ConfidentialStore](#confidentialstore)
@@ -23,6 +23,7 @@
 
 </div>
 
+<!-- omit from toc -->
 ## Overview
 
 This document provides an overview of the Confidential Data Store, an essential component of the SUAVE protocol. The Confidential Store serves as a secure and privacy-focused storage system, by exposing a key-value store for safeguarding confidential bid-related data. Only those with appropriate permissions (peekers) can access the stored data, thus ensuring privacy and control.

--- a/specs/rigil/mevm.md
+++ b/specs/rigil/mevm.md
@@ -1,4 +1,5 @@
-# MEVM <!-- omit from toc -->
+<!-- omit from toc -->
+# MEVM
 
 <div class="hideInDocs">
 

--- a/specs/rigil/precompiles.md
+++ b/specs/rigil/precompiles.md
@@ -1,4 +1,5 @@
-# Precompiles <!-- omit from toc -->
+<!-- omit from toc -->
+# Precompiles
 
 <div class="hideInDocs">
 
@@ -8,7 +9,7 @@
 
 - [Overview](#overview)
 - [Precompiles Governance](#precompiles-governance)
-- [Precompiles](#precompiles)
+- [Precompiles](#precompiles-1)
   - [`IsConfidential`](#isconfidential)
   - [`ConfidentialInputs`](#confidentialinputs)
   - [`ConfidentialStore`](#confidentialstore)

--- a/specs/rigil/suave-chain.md
+++ b/specs/rigil/suave-chain.md
@@ -1,4 +1,5 @@
-# Suave Chain <!-- omit from toc -->
+<!-- omit from toc -->
+# Suave Chain
 
 <div class="hideInDocs">
 


### PR DESCRIPTION
Docusaurus shows the comments if used as suffix. Moved them above the headers, still works with the markdown all-in-one extension.