### PR TITLE
Fix issues when rendering in docs

### DIFF
--- a/specs/rigil/README.md
+++ b/specs/rigil/README.md
@@ -1,11 +1,6 @@
 ---
 title: Rigil Testnet
 description: Rigil is the first testnet for SUAVE. It is an experimental sandbox and foundation for building MEV applications in a decentralized and private manner.
-keywords:
-  - rigil
-  - tesnet
-  - suave
-  - experimental
 ---
 
 <!-- omit from toc -->

--- a/specs/rigil/bridge.md
+++ b/specs/rigil/bridge.md
@@ -1,9 +1,6 @@
 ---
 title: Bridge
 description: A description of our current bridge implementation, which is meant to enable rapid prototyping.
-keywords:
-  - bridge
-  - suave
 ---
 
 <!-- no toc -->

--- a/specs/rigil/computor.md
+++ b/specs/rigil/computor.md
@@ -1,9 +1,6 @@
 ---
 title: Computor
 description: SUAVE computors contain all necessary components to accept, process, and route confidential compute requests and results.
-keywords:
-  - computor
-  - suave
 ---
 
 <!-- omit from toc -->

--- a/specs/rigil/confidential-data-store.md
+++ b/specs/rigil/confidential-data-store.md
@@ -1,11 +1,6 @@
 ---
 title: Confidential Data Store
 description: This essential component of the SUAVE protocol serves as a secure and privacy-focused storage system.
-keywords:
-  - confidential
-  - data
-  - store
-  - suave
 ---
 
 <!-- omit from toc -->

--- a/specs/rigil/mevm.md
+++ b/specs/rigil/mevm.md
@@ -1,10 +1,6 @@
 ---
 title: MEVM
 description: The MEVM modifies the EVM by adding a new runtime, interpreter, and execution backend so as to enable anyone to create MEV applications.
-keywords:
-  - MEVM
-  - EVM
-  - suave
 ---
 
 <!-- omit from toc -->

--- a/specs/rigil/precompiles.md
+++ b/specs/rigil/precompiles.md
@@ -1,9 +1,6 @@
 ---
 title: Precompiles
 description: Precompiles are a convenient tool within the EVM that enable direct execution of predefined functions, simplifying development of complex applications.
-keywords:
-  - precompiles
-  - suave
 ---
 
 <!-- omit from toc -->

--- a/specs/rigil/suave-chain.md
+++ b/specs/rigil/suave-chain.md
@@ -1,9 +1,6 @@
 ---
 title: Suave Chain
 description: The main purpose of the SUAVE chain is to reach (and maintain) consensus about smart contract code for use cases such as order flow auctions, solvers, block builders, etc.
-keywords:
-  - chain
-  - suave
 ---
 
 <!-- omit from toc -->


### PR DESCRIPTION
This PR does 2 things:

1. Adds metadata headings for all pages so that (a) they render properly in the Docusaurus sidebar and (b) they get an OK SEO score when integrated into any other site which may display them.
2. Changes all links in `computor.md` to be relative so that they don't break in Docusaurus.

It also, because I can't resist, changes a little grammar etc., but I tried to save the majority of that for another PR.